### PR TITLE
fix vault image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - keycloak
 
   vault:
-    image: vault
+    image: hashicorp/vault
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8200/ui/vault/auth" ]
       interval: 5s


### PR DESCRIPTION
see deprecation notice in https://github.com/hashicorp/docker-vault:
_Users of Docker images should pull from hashicorp/vault instead of vault_ 